### PR TITLE
Some minor bug fixes and enhancements to the OSCMessage class

### DIFF
--- a/OSCMessage.h
+++ b/OSCMessage.h
@@ -257,8 +257,8 @@ public:
 	int getAddress(char * buffer, int offset = 0);
 	int getAddress(char * buffer, int offset, int len);
 	
-	// TODO: int getAddressLength(int offset = 0);
-	
+    int getDataCount();
+    int getAddressLength(int offset = 0);
 
 /*=============================================================================
 	TESTING DATA


### PR DESCRIPTION
- Fixed a boundary case when sending blob data that is already 32-bit al...igned along with additional parameters.
- Removed code to try and skip padding at the end of the types list when filling a message. I think the types list is just a null-terminated string, which doesn't include padding to align it to 32-bits, similar to the address.
- Added getDataCount method to OSCMessage
- Added getAddressLength method to OSCMessage
- Minor tweaks to buffer management for clarity
