### PR TITLE
Fix decode state when emptying a OSCMessage so fill() can be called agai...

### DIFF
--- a/OSCMessage.cpp
+++ b/OSCMessage.cpp
@@ -94,6 +94,7 @@ void OSCMessage::empty(){
     free(data);
     data = NULL;
     dataCount = 0;
+    decodeState = STANDBY;
     clearIncomingBuffer();
 }
 


### PR DESCRIPTION
Fix decode state when emptying a OSCMessage so fill() can be called again
