### PR TITLE
Master

### DIFF
--- a/OSCBoards.h
+++ b/OSCBoards.h
@@ -68,52 +68,53 @@
 #endif
 
 #endif
-
-#ifndef analogInputToDigitalPin
-int analogInputToDigitalPin(int i)
-{
-    switch(i)
-    {
-        case  0: return A0;
-        case 1: return A1;
-        case 2: return A2;
-        case 3: return A3;
-        case 4: return A4;
-        case 5: return A5;
-#ifdef A6
-        case 6: return A6;
-#endif
-#ifdef A7
-        case 7: return A7;
-#endif
-#ifdef A8
-        case 8: return A8;
-#endif
-#ifdef A9
-        case 9: return A9;
-#endif
-#ifdef A10
-        case 10: return A10;
-#endif
-#ifdef A11
-        case 11: return A11;
-#endif
-#ifdef A12
-        case 12: return A12;
-#endif
-#ifdef A13
-        case 13: return A13;
-#endif
-#ifdef A14
-        case 14: return A14;
-#endif
-#ifdef A15
-        case 15: return A15;
-#endif
-#ifdef A16    
-        case 16: return A16;
-#endif
-    }
-}
-#endif
+#ifndef ESP8266
+    #ifndef analogInputToDigitalPin
+        int analogInputToDigitalPin(int i)
+        {
+            switch(i)
+            {
+                case 0: return A0;
+                case 1: return A1;
+                case 2: return A2;
+                case 3: return A3;
+                case 4: return A4;
+                case 5: return A5;
+        #ifdef A6
+                case 6: return A6;
+        #endif
+        #ifdef A7
+                case 7: return A7;
+        #endif
+        #ifdef A8
+                case 8: return A8;
+        #endif
+        #ifdef A9
+                case 9: return A9;
+        #endif
+        #ifdef A10
+                case 10: return A10;
+        #endif
+        #ifdef A11
+                case 11: return A11;
+        #endif
+        #ifdef A12
+                case 12: return A12;
+        #endif
+        #ifdef A13
+                case 13: return A13;
+        #endif
+        #ifdef A14
+                case 14: return A14;
+        #endif
+        #ifdef A15
+                case 15: return A15;
+        #endif
+        #ifdef A16    
+                case 16: return A16;
+        #endif
+            }
+        }
+    #endif
+#endif //for ESP8266 ifndef
 

--- a/OSCData.cpp
+++ b/OSCData.cpp
@@ -34,12 +34,14 @@ OSCData::OSCData(int32_t i){
 	bytes = 4;
 	data.i = i;
 }
+#ifndef ESP8266
 OSCData::OSCData(int i){
 	error = OSC_OK;
 	type = 'i';
 	bytes = 4;
 	data.i = i;
 }
+#endif
 OSCData::OSCData(unsigned int i){
 	error = OSC_OK;
 	type = 'i';
@@ -170,7 +172,11 @@ int32_t OSCData::getInt(){
     if (type == 'i'){
         return data.i;
     } else {
+    #ifndef ESP8266
         return NULL;
+    #else
+        return -1; 
+    #endif
     }
 }
 osctime_t OSCData::getTime(){
@@ -185,7 +191,11 @@ float OSCData::getFloat(){
     if (type == 'f'){
         return data.f;
     } else {
+    #ifndef ESP8266
         return NULL;
+    #else
+        return -1; 
+    #endif
     }
 }
 
@@ -193,7 +203,11 @@ double OSCData::getDouble(){
     if (type == 'd'){
         return data.d;
     } else {
+    #ifndef ESP8266
         return NULL;
+    #else
+        return -1; 
+    #endif
     }
 }
 bool OSCData::getBoolean(){
@@ -203,7 +217,11 @@ bool OSCData::getBoolean(){
         return false;
     }
     else
+    #ifndef ESP8266
         return NULL;
+    #else
+        return -1; 
+    #endif
 }
 
 int OSCData::getString(char * strBuffer, int length){
@@ -211,7 +229,11 @@ int OSCData::getString(char * strBuffer, int length){
         strncpy(strBuffer, data.s, bytes);
         return bytes;
     } else {
+    #ifndef ESP8266
         return NULL;
+    #else
+        return -1; 
+    #endif
     }
 }
 
@@ -220,6 +242,10 @@ int OSCData::getBlob(uint8_t * blobBuffer, int length){
         memcpy(blobBuffer, data.b, bytes);
         return bytes;
     } else {
+    #ifndef ESP8266
         return NULL;
+    #else
+        return -1; 
+    #endif
     }
 }

--- a/OSCData.h
+++ b/OSCData.h
@@ -92,7 +92,9 @@ public:
 	OSCData (int16_t);
 #endif
 	OSCData (int32_t);
+#ifndef ESP8266
     OSCData (int);
+#endif
     OSCData (unsigned int);
 	OSCData (float);
 	OSCData (double);

--- a/OSCMessage.cpp
+++ b/OSCMessage.cpp
@@ -128,7 +128,11 @@ int32_t OSCMessage::getInt(int position){
 	if (!hasError()){
 		return datum->getInt();
     } else {
-        return NULL;
+        #ifndef ESP8266
+            return NULL;
+        #else
+            return -1; 
+        #endif
     }
 }
 osctime_t OSCMessage::getTime(int position){
@@ -144,7 +148,11 @@ float OSCMessage::getFloat(int position){
 	if (!hasError()){
 		return datum->getFloat();
     } else {
-        return NULL;
+        #ifndef ESP8266
+            return NULL;
+        #else
+            return -1; 
+        #endif
     }
 }
 
@@ -153,7 +161,11 @@ double OSCMessage::getDouble(int position){
 	if (!hasError()){
 		return datum->getDouble();
     } else {
-        return NULL;
+        #ifndef ESP8266
+            return NULL;
+        #else
+            return -1; 
+        #endif
     }
 }
 bool  OSCMessage::getBoolean(int position){
@@ -161,7 +173,11 @@ bool  OSCMessage::getBoolean(int position){
 	if (!hasError()){
 		return datum->getBoolean();
     } else {
-        return NULL;
+        #ifndef ESP8266
+            return NULL;
+        #else
+            return -1; 
+        #endif
     }
 }
 
@@ -172,7 +188,11 @@ int OSCMessage::getString(int position, char * buffer, int bufferSize){
         int copyBytes = bufferSize < datum->bytes? bufferSize : datum->bytes;
 		return datum->getString(buffer, copyBytes);
     } else {
-        return NULL;
+        #ifndef ESP8266
+            return NULL;
+        #else
+            return -1; 
+        #endif
     }
 }
 
@@ -183,7 +203,11 @@ int OSCMessage::getBlob(int position, uint8_t * buffer, int bufferSize){
         int copyBytes = bufferSize < datum->bytes? bufferSize : datum->bytes;
 		return datum->getBlob(buffer, copyBytes);
     } else {
-        return NULL;
+        #ifndef ESP8266
+            return NULL;
+        #else
+            return -1; 
+        #endif
     }
 }
 
@@ -192,7 +216,11 @@ char OSCMessage::getType(int position){
 	if (!hasError()){
 		return datum->type;
 	} else {
-        return NULL;
+        #ifndef ESP8266
+            return NULL;
+        #else
+            return '\0'; 
+        #endif
     }
 }
 


### PR DESCRIPTION
To ensure compatibility with Arduino/ESP8266, these edits disable specific methods and definitions only when ESP8266 is defined. These changes are manifested through preprocessor directives by which code operation should remain unchanged for boards other than ESP8266.