### PR TITLE
Allow OSCBundles to receive osc messages

### DIFF
--- a/OSCBundle.cpp
+++ b/OSCBundle.cpp
@@ -289,6 +289,8 @@ void OSCBundle::decode(uint8_t incomingByte){
             if (incomingByte == '#'){
                 decodeState = HEADER;
             } else if (incomingByte == '/'){
+                add();//add a simple message to the bundle
+                decodeMessage(incomingByte);
                 decodeState = MESSAGE;
             }
             break;


### PR DESCRIPTION
OSCBundle class was (intentionally?) restricted to receiving osc
bundled. It can be useful to allow it to parse simple osc messages in
situations where we don't know what kind of osc data is received.