### PR TITLE
Remove garbage characters from UDPEcho that are causing compiler errors

### DIFF
--- a/examples/UDPEcho/UDPEcho.ino
+++ b/examples/UDPEcho/UDPEcho.ino
@@ -42,8 +42,8 @@ void read_mac() {
 }
 #else
 void read_mac() {}
- byte mac[] = {
-      0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED }; // you can find this written on the board of some Arduino Ethernets or shields
+ byte mac[] = {  
+  0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED }; // you can find this written on the board of some Arduino Ethernets or shields
 #endif
 
 void setup() {


### PR DESCRIPTION
UDPEcho:45: error: stray '\302' in program
  byte mac[] = {
 ^
UDPEcho:45: error: stray '\240' in program
UDPEcho:46: error: stray '\302' in program
       0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED }; // you can find this written on the board of some Arduino Ethernets or shields
     ^
UDPEcho:46: error: stray '\240' in program