### PR TITLE
OSCMessage/OSCBundle::dispatch/route: switch to std::function

### DIFF
--- a/OSCBundle.cpp
+++ b/OSCBundle.cpp
@@ -141,7 +141,7 @@ OSCMessage * OSCBundle::getOSCMessage(int pos){
  =============================================================================*/
 
 
-bool OSCBundle::dispatch(const char * pattern, void (*callback)(OSCMessage&), int initial_offset){
+bool OSCBundle::dispatch(const char * pattern, std::function<void(OSCMessage &)> callback, int initial_offset){
 	bool called = false;
 	for (int i = 0; i < numMessages; i++){
         OSCMessage msg = getOSCMessage(i);
@@ -151,7 +151,7 @@ bool OSCBundle::dispatch(const char * pattern, void (*callback)(OSCMessage&), in
 }
 
 
-bool OSCBundle::route(const char * pattern, void (*callback)(OSCMessage&, int), int initial_offset){
+bool OSCBundle::route(const char * pattern, std::function<void(OSCMessage &, int)> callback, int initial_offset){
 	bool called = false;
 	for (int i = 0; i < numMessages; i++){
         OSCMessage msg = getOSCMessage(i);

--- a/OSCBundle.h
+++ b/OSCBundle.h
@@ -137,11 +137,11 @@ public:
 
 	//if the bundle contains a message that matches the pattern, 
 	//call the function callback on that message
-	bool dispatch(const char * pattern, void (*callback)(OSCMessage&), int = 0);
+	bool dispatch(const char * pattern, std::function<void(OSCMessage &)> callback, int = 0);
 	
 	//like dispatch, but allows for partial matches
 	//the address match offset is sent as an argument to the callback
-	bool route(const char * pattern, void (*callback)(OSCMessage&, int), int = 0);
+	bool route(const char * pattern, std::function<void(OSCMessage &, int)> callback, int = 0);
 	
 /*=============================================================================
      SIZE

--- a/OSCMessage.cpp
+++ b/OSCMessage.cpp
@@ -375,7 +375,7 @@ bool OSCMessage::fullMatch( const char * pattern, int addr_offset){
 	return (ret==3);
 }
 
-bool OSCMessage::dispatch(const char * pattern, void (*callback)(OSCMessage &), int addr_offset){
+bool OSCMessage::dispatch(const char * pattern, std::function<void(OSCMessage &)> callback, int addr_offset){
 	if (fullMatch(pattern, addr_offset)){
 		callback(*this);
 		return true;
@@ -384,7 +384,7 @@ bool OSCMessage::dispatch(const char * pattern, void (*callback)(OSCMessage &), 
 	}
 }
 
-bool OSCMessage::route(const char * pattern, void (*callback)(OSCMessage &, int), int initial_offset){
+bool OSCMessage::route(const char * pattern, std::function<void(OSCMessage &, int)> callback, int initial_offset){
 	int match_offset = match(pattern, initial_offset);
 	if (match_offset>0){
 		callback(*this, match_offset + initial_offset);

--- a/OSCMessage.h
+++ b/OSCMessage.h
@@ -28,6 +28,7 @@
 
 #include "OSCData.h"
 #include <Print.h>
+#include <functional>
 
 
 class OSCMessage
@@ -302,12 +303,12 @@ public:
 	int match( const char * pattern, int = 0);
 
 	//calls the function with the message as the arg if it was a full match
-	bool dispatch(const char * pattern, void (*callback)(OSCMessage &), int = 0);
+	bool dispatch(const char * pattern, std::function<void(OSCMessage &)> callback, int = 0);
 
 	//like dispatch, but allows for partial matches
 	//the address match offset is sent as an argument to the callback
 	//also room for an option address offset to allow for multiple nested routes
-	bool route(const char * pattern, void (*callback)(OSCMessage &, int), int = 0);
+	bool route(const char * pattern, std::function<void(OSCMessage &, int)> callback, int = 0);
 
 
 


### PR DESCRIPTION
To improve the usability of `OSCMessage` and `OSCBundle`, I propose replacing the C-style callbacks of `dispatch` and `route` with `std::function`.

## Proposed change

In [`OSCMessage.h`](https://github.com/CNMAT/OSC/blob/master/OSCMessage.h#L293) and [`OSCBundle.h`](https://github.com/CNMAT/OSC/blob/master/OSCBundle.h#L134), change the signature of `dispatch` and `route` from

```c++
bool dispatch(const char * pattern, void (*callback)(OSCMessage &), int = 0);

bool route(const char * pattern, void (*callback)(OSCMessage &, int), int = 0);
```

to

```c++
bool dispatch(const char * pattern, std::function<void(OSCMessage &)> callback, int = 0);

bool route(const char * pattern, std::function<void(OSCMessage &, int)> callback, int = 0);
```

The implementation of these function do not change so I expect little issues.

## Why?

Using `std::function` enables a couple of cool C++11 functions while still being compatible with regular function pointers. It isn't any more complex than regular function pointers and allows more experienced C++ users to clean-up their code.

### Advantages

`std::function` accepts lambda's that capture context, allowing you to keep related logic close to each other. For instance:

```c++
float val;
...
message.dispatch("/update", [&val](OSCMessage &msg) {
    // process the latest update - update external variable
    if (msg.isFloat(0)) {
        val = msg.getFloat(0);
    }
});
```

It allows the user to pass member functions of classes (using `std::bind`). For instance:

```c++
class OscHandler {
public:
    void handleTest(OSCMessage &);
};

OscHandler myHandler;
...
message.dispatch("/test", std::bind(&OscHandler::handleTest, myHandler, std::placeholders::_1));

// std::bind allows you to drop parameters, so you can also bind handleTest to route
message.route("/test", std::bind(&OscHandler::handleTest, myHandler, std::placeholders::_1));
```

### Related issues

This would resolve issues like #22.

## \<functional\> / C++11

`std::function` requires C++11, but since C++11 is enabled by default since Arduino 1.6.6 this should be fine. The README also recommends installing Arduino 1.8.5.

So I propose adding it as is and assume users use a recent version of Arduino. This might break compilation for users using (very) old compilers or users that still don't have C++11 enabled.

Alternatively, we could use preprocessor defines to compile conditionally. Something like:

```c++
#if __cplusplus > 199711L	// C++11 compliant compiler
    #include <functional>
#endif
...
```
