### PR TITLE
Add version and ESP32 / ESP8266 to platforms

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,5 +1,6 @@
 {
   "name": "OSC",
+  "version": "1.0.0",
   "keywords": "sound, encoding, OSC",
   "description": "Open Sound Control (OSC) is an open, transport-independent, message-based encidubg developed for communication among computers, sound synthesizers, and other multimedia devices.",
   "authors": [
@@ -22,6 +23,8 @@
   "platforms": [
     "atmelavr",
     "atmelsam",
-    "teensy"
+    "teensy",
+    "espressif32",
+    "espressif8266"
   ]
 }


### PR DESCRIPTION
This fixes issue #130  and adds a version number.
This will allow PlatformIO developers to properly use this library with ESP32 and ESP8266 boards