### PR TITLE
Add support for SLIP encoded bluetooth serial

### DIFF
--- a/SLIPEncodedBluetoothSerial.cpp
+++ b/SLIPEncodedBluetoothSerial.cpp
@@ -1,0 +1,181 @@
+#include "SLIPEncodedBluetoothSerial.h"
+#include "BluetoothSerial.h"
+
+/*
+ CONSTRUCTOR
+ */
+//instantiate with the tranmission layer
+//use BluetoothSerial
+SLIPEncodedBluetoothSerial::SLIPEncodedBluetoothSerial(BluetoothSerial &s){
+	serial = &s;
+	rstate = CHAR;
+}
+
+static const uint8_t eot = 0300;
+static const uint8_t slipesc = 0333;
+static const uint8_t slipescend = 0334;
+static const uint8_t slipescesc = 0335;
+/*
+ SERIAL METHODS
+ */
+bool SLIPEncodedBluetoothSerial::endofPacket()
+{
+	if(rstate == SECONDEOT)
+	{
+		rstate = CHAR; 
+		return true;
+	}
+	if (rstate==FIRSTEOT)
+	{
+        if(serial->available())
+        {
+            uint8_t c =serial->peek();
+            if(c==eot)
+            {
+                serial->read(); // throw it on the floor
+            }
+        }
+		rstate = CHAR;
+		return true;
+	}
+	return false;
+}
+int SLIPEncodedBluetoothSerial::available(){
+back:
+	int cnt = serial->available();
+	
+	if(cnt==0)
+		return 0;
+	if(rstate==CHAR)
+	{
+		uint8_t c =serial->peek();
+		if(c==slipesc)
+		{
+			rstate = SLIPESC;
+			serial->read(); // throw it on the floor
+			goto back;
+		}
+		else if( c==eot)
+		{
+			rstate = FIRSTEOT;
+			serial->read(); // throw it on the floor
+			goto back;
+		}
+		return 1; // we may have more but this is the only sure bet
+	}
+	else if(rstate==SLIPESC)	
+		return 1;
+	else if(rstate==FIRSTEOT)
+	{
+		if(serial->peek()==eot)
+		{
+			rstate = SECONDEOT;
+			serial->read(); // throw it on the floor
+			return 0;
+		}		
+		rstate = CHAR;
+	}else if (rstate==SECONDEOT) {
+		rstate = CHAR;
+	}
+	
+	return 0;
+		
+}
+
+//reads a byte from the buffer
+int SLIPEncodedBluetoothSerial::read(){
+back:
+	uint8_t c = serial->read();
+	if(rstate==CHAR)
+	{
+		if(c==slipesc)
+		{
+			rstate=SLIPESC;
+			goto back;
+		}	
+		else if(c==eot){
+		
+			return -1; // xxx this is an error
+		}
+		return c;
+	}
+	else
+	if(rstate==SLIPESC)
+	{
+		rstate=CHAR;
+		if(c==slipescend)
+			return eot;
+		else if(c==slipescesc)
+			return slipesc;
+			else {
+				// insert some error code here
+				return -1;
+			}
+
+	}
+	else
+		return -1;
+}
+
+// as close as we can get to correct behavior
+int SLIPEncodedBluetoothSerial::peek(){
+	uint8_t c = serial->peek();
+	if(rstate==SLIPESC)
+	{
+		if(c==slipescend)
+			return eot;
+		else if(c==slipescesc)
+			return slipesc;
+	}
+	return c; 
+}
+
+//the arduino and wiring libraries have different return types for the write function
+#if defined(WIRING) || defined(BOARD_DEFS_H)
+
+//encode SLIP
+ void SLIPEncodedBluetoothSerial::write(uint8_t b){
+	if(b == eot){ 
+		serial->write(slipesc);
+		return serial->write(slipescend); 
+	} else if(b==slipesc) {  
+		serial->write(slipesc);
+		return serial->write(slipescesc); 
+	} else {
+		return serial->write(b);
+	}	
+}
+void SLIPEncodedBluetoothSerial::write(const uint8_t *buffer, size_t size) {  while(size--) write(*buffer++); }
+#else
+//encode SLIP
+size_t SLIPEncodedBluetoothSerial::write(uint8_t b){
+	if(b == eot){ 
+		serial->write(slipesc);
+		return serial->write(slipescend); 
+	} else if(b==slipesc) {  
+		serial->write(slipesc);
+		return serial->write(slipescesc); 
+	} else {
+		return serial->write(b);
+	}	
+}
+size_t SLIPEncodedBluetoothSerial::write(const uint8_t *buffer, size_t size) { size_t result=0; while(size--) result = write(*buffer++); return result; }
+
+#endif
+
+void SLIPEncodedBluetoothSerial::begin(String name){
+	serial->begin(name);
+}
+//SLIP specific method which begins a transmitted packet
+void SLIPEncodedBluetoothSerial::beginPacket() { 	serial->write(eot); }
+
+//signify the end of the packet with an EOT
+void SLIPEncodedBluetoothSerial::endPacket(){
+	serial->write(eot);
+
+}
+
+void SLIPEncodedBluetoothSerial::flush(){
+	serial->flush();
+}
+

--- a/SLIPEncodedBluetoothSerial.h
+++ b/SLIPEncodedBluetoothSerial.h
@@ -1,0 +1,62 @@
+/*
+Extends the Serial class to encode SLIP over serial
+*/
+
+#ifndef SLIPEncodedBluetoothSerial_h
+#define SLIPEncodedBluetoothSerial_h
+
+
+#include "Arduino.h"
+#include <Stream.h>
+#include "BluetoothSerial.h"
+
+
+class SLIPEncodedBluetoothSerial: public Stream{
+	
+private:
+	enum erstate {CHAR, FIRSTEOT, SECONDEOT, SLIPESC } rstate;
+	
+	//the serial port used
+	BluetoothSerial * serial;
+
+	
+public:
+	
+	//the serial port used
+	SLIPEncodedBluetoothSerial(BluetoothSerial & );
+
+	
+	int available();
+	int read();
+	int peek();
+	void flush();
+	
+	//same as Serial.begin
+	void begin(String);
+    
+    //SLIP specific method which begins a transmitted packet
+	void beginPacket();
+	
+	//SLIP specific method which ends a transmittedpacket
+	void endPacket();
+	// SLIP specific method which indicates that an EOT was received 
+	bool endofPacket();
+	
+	
+//the arduino and wiring libraries have different return types for the write function
+#if defined(WIRING) || defined(BOARD_DEFS_H)
+	void write(uint8_t b);
+  void write(const uint8_t *buffer, size_t size);
+
+#else
+	//overrides the Stream's write function to encode SLIP
+	size_t write(uint8_t b);
+    size_t write(const uint8_t *buffer, size_t size);
+
+	//using Print::write;
+#endif
+
+};
+
+
+#endif


### PR DESCRIPTION
Hey,

I've added header and source files for a SLIP encoded bluetooth serial conncetion (which takes a device name as an argument instead of a baud rate.

Works for me on an ESP32, here's an example sketch:
https://git.kompot.si/g1smo/pifcamp-2021/src/branch/master/osc32final/osc32final.ino

Cheers