### PR TITLE
fix: Broken platformio library.json manifest

### DIFF
--- a/library.json
+++ b/library.json
@@ -12,7 +12,7 @@
     {
       "name": "Yotam Mann",
       "url": "http://yotammann.info"
-    }    
+    }
   ],
   "repository":
   {
@@ -21,5 +21,4 @@
   },
   "frameworks": "arduino",
   "platforms": "*"
-  ]
 }


### PR DESCRIPTION
Hi, there is an extranous `]` in the platformio manifest library.json file which results in an error in pio about "broken manifest", this fixes it. Thanks :)